### PR TITLE
fix typo

### DIFF
--- a/appvm-scripts/etc/X11/xinit/xinitrc.d/qubes-keymap.sh
+++ b/appvm-scripts/etc/X11/xinit/xinitrc.d/qubes-keymap.sh
@@ -19,7 +19,7 @@ set_keyboard_layout() {
     fi
 
     if [ -n "$KEYMAP_OPTIONS" ]; then
-        KEYMAP_OPTIONS="-options $KEYMAP_OPTIONS"
+        KEYMAP_OPTIONS="-option $KEYMAP_OPTIONS"
     fi
 
     # Set layout on all DISPLAY


### PR DESCRIPTION
setxkbmap use -option flag setup option. Multiply options need multiply -option flag.